### PR TITLE
Add -s option for attaching shared directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The following command-line arguments are supported:
     -i <initrd path>
     -d <disc image path>
     -c <CDROM image path>
+    -s <shared dir path>[:<tag>[:{ro, rw}]]
     -b <bridged ethernet interface>
     -p <number of processors>
     -m <memory size in MB>
@@ -49,6 +50,14 @@ Only the `-k` argument is required (for a path to the kernel image), and all oth
 The `-t` option permits the console to either use stdin/stdout (option `0`), or to create a pseudo terminal (option `1`, the default) and wait for you to attach something to it, as in the example below.  The pseudo terminal (pty) approach gives a useful interactive console (particularly handy for setting up your VM), but stdin/stdout and immediate startup are more useful for launching VMs in a script.
 
 Multiple disc images can be attached by using several `-d` or `-c` options.  The discs are attached in the order they are given on the command line, which should then influence which device they appear as.  For example, `-d foo -d bar -c blah` will create three virtio-blk devices, `/dev/vda`, `/dev/vdb`, `/dev/vdc` attached to _foo_, _bar_ and _blah_ respectively.  Up to 8 discs can be attached.
+
+Up to 8 shared directories may be attached with the `-s` option. They are each labelled with a tag;
+if none is specified, the directory name is used. In they guest VM, they may be mounted using:
+```
+mount -t virtiofs <tag> <mount point>
+```
+Note that this requires virtiofs support, which is available in recent distributions such as Ubuntu
+22.04. Directories may be specified as read only by adding the `:ro` suffix.
 
 The kernel should be uncompressed.  The initrd may be a gz.  Disc images are raw/flat files (nothing fancy like qcow2).
 


### PR DESCRIPTION
Adds support for sharing host directories with the guest using [VirtioFS devices](https://developer.apple.com/documentation/virtualization/shared_directories?language=objc).
The implementation is largely analog to the disk options.